### PR TITLE
Feature: Implement dynamic step invocation with class instances

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -5,6 +5,9 @@
       "syntax": "typescript",
       "decorators": true
     },
+    "transform": {
+      "decoratorVersion": "2022-03"
+    },
     "target": "esnext"
   },
   "module": {

--- a/src/__tests__/calculator.steps.ts
+++ b/src/__tests__/calculator.steps.ts
@@ -18,6 +18,8 @@ export default class CalculatorSteps {
 
   constructor(readonly calculator: Calculator) {}
 
+  @Given("X is {int}")
+  @Given("Y is {int}")
   @Given(/[AB] is (\d)/)
   public stepIs(value: number) {
     this.calculator.add(value);
@@ -28,7 +30,8 @@ export default class CalculatorSteps {
     this.result = this.calculator.sum();
   }
 
-  @Then("The result is {int}")
+  @Then("The result equals {int}")
+  @Then(/The result is (\w+)/)
   public stepResult(expectedResult: number) {
     expect(this.result).toStrictEqual(expectedResult);
   }

--- a/src/__tests__/features/calculator.feature
+++ b/src/__tests__/features/calculator.feature
@@ -1,7 +1,13 @@
 Feature: Calculator
 
-  Scenario: Add two numbers
+  Scenario: Add two numbers (with regular expressions)
     Given A is 1
     And B is 2
     When I add the values
-    Then The result is 3
+    Then The result is 012
+
+  Scenario: Subtract two numbers (with cucumber expressions)
+    Given X is 1
+    And Y is 2
+    When I add the values
+    Then The result equals 3

--- a/src/__tests__/instanceManager.test.ts
+++ b/src/__tests__/instanceManager.test.ts
@@ -1,0 +1,84 @@
+import { Binding } from "../decorators";
+import { InstanceManager } from "../instanceManager";
+
+describe("InstanceManager", () => {
+  @Binding()
+  class TestClass {}
+
+  @Binding()
+  class TestClass2 {}
+
+  @Binding([TestClass])
+  class TestClassWithOneLevelOfDependencies {
+    constructor(private readonly testClass: TestClass) {}
+  }
+
+  @Binding([TestClassWithOneLevelOfDependencies])
+  class TestClassWithTwoLevelsOfDependencies {
+    constructor(private readonly testClassWithOneLevelOfDependencies: TestClassWithOneLevelOfDependencies) {}
+  }
+
+  @Binding([TestClass, TestClass2])
+  class TestClassWithTwoDependency {
+    constructor(
+      private readonly testClass: TestClass,
+      private readonly testClass2: TestClass2,
+    ) {}
+  }
+
+  describe("getOrSaveInstance", () => {
+    it("should return an instance of the class", () => {
+      const instanceManager = new InstanceManager();
+      const instance = instanceManager.getOrSaveInstance(TestClass);
+
+      expect(instance).toBeDefined();
+    });
+
+    it("should return the same instance of the class", () => {
+      const instanceManager = new InstanceManager();
+      const instance1 = instanceManager.getOrSaveInstance(TestClass);
+      const instance2 = instanceManager.getOrSaveInstance(TestClass);
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it("should return an instance of the class with one level of dependencies", () => {
+      const instanceManager = new InstanceManager();
+      const instance = instanceManager.getOrSaveInstance(TestClassWithOneLevelOfDependencies);
+      const dependency = instanceManager.getInstance(TestClass);
+
+      expect(instance).toBeDefined();
+      expect(dependency).toBeDefined();
+    });
+
+    it("should return an instance of the class with two levels of dependencies", () => {
+      const instanceManager = new InstanceManager();
+      const instance = instanceManager.getOrSaveInstance(TestClassWithTwoLevelsOfDependencies);
+      const dependency = instanceManager.getInstance(TestClassWithOneLevelOfDependencies);
+      const subDependency = instanceManager.getInstance(TestClass);
+
+      expect(instance).toBeDefined();
+      expect(dependency).toBeDefined();
+      expect(subDependency).toBeDefined();
+    });
+
+    it("should return an instance of the class with two dependencies", () => {
+      const instanceManager = new InstanceManager();
+      const instance = instanceManager.getOrSaveInstance(TestClassWithTwoDependency);
+      const dependency1 = instanceManager.getInstance(TestClass);
+      const dependency2 = instanceManager.getInstance(TestClass2);
+
+      expect(instance).toBeDefined();
+      expect(dependency1).toBeDefined();
+      expect(dependency2).toBeDefined();
+    });
+  });
+
+  describe("getInstance", () => {
+    it("should throw an error if no instance is found", () => {
+      const instanceManager = new InstanceManager();
+
+      expect(() => instanceManager.getInstance(TestClass)).toThrow();
+    });
+  });
+});

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -48,7 +48,7 @@ describe("Binding registry", () => {
     it("should have the same step function when there's multiple pattern", () => {
       const { stepDefinition: definition1 } = BindingRegistry.instance.getStep("I have a step");
       const { stepDefinition: definition2 } = BindingRegistry.instance.getStep("I have a second pattern");
-      expect(definition1.definition).toBe(definition2.definition);
+      expect(definition1.method).toBe(definition2.method);
     });
 
     it("should throw en error if the class is not decorated with @Binding", () => {

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,9 +1,11 @@
 import { BindingRegistry } from "../registry";
-import { Step } from "../decorators";
+import { Binding, Step } from "../decorators";
 
 describe("Binding registry", () => {
+  @Binding()
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   class TestBindings {
+    @Step("I have a second pattern")
     @Step("I have a step")
     public stepA() {
       return "step";
@@ -16,6 +18,14 @@ describe("Binding registry", () => {
 
     @Step("I have a duplicate step")
     public stepC() {
+      return "step";
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  class TestBindings2 {
+    @Step("I have a new step")
+    public stepA() {
       return "step";
     }
   }
@@ -33,6 +43,16 @@ describe("Binding registry", () => {
 
     it("should throw an error if multiple step definitions are found for the given text", () => {
       expect(() => BindingRegistry.instance.getStep("I have a duplicate step")).toThrow();
+    });
+
+    it("should have the same step function when there's multiple pattern", () => {
+      const { stepDefinition: definition1 } = BindingRegistry.instance.getStep("I have a step");
+      const { stepDefinition: definition2 } = BindingRegistry.instance.getStep("I have a second pattern");
+      expect(definition1.definition).toBe(definition2.definition);
+    });
+
+    it("should throw en error if the class is not decorated with @Binding", () => {
+      expect(() => BindingRegistry.instance.getStep("I have a new step")).toThrow();
     });
   });
 });

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -4,42 +4,40 @@ import { BindingRegistry } from "../registry";
 import { StepMetadata } from "../types";
 import { BindingDecorator, StepDecorator } from "./decorators.types";
 
-const propertyKeys = <T>(target: T): (keyof T)[] => Object.getOwnPropertyNames(target) as (keyof T)[];
-
 export const Binding: BindingDecorator = (dependencies) => (target) => {
-  for (const key of propertyKeys(target.prototype)) {
+  const propertyKeys = Reflect.ownKeys(target.prototype);
+
+  for (const key of propertyKeys) {
     const steps = Reflect.getMetadata("steps", target.prototype[key]) as StepMetadata[];
 
     if (steps) {
       for (const step of steps) {
-        BindingRegistry.instance.registerStep(target, {
-          pattern: step.pattern,
-          definition: target.prototype[key],
-          options: step.options,
+        BindingRegistry.instance.registerStep({
+          ...step,
+          binding: target,
+          method: target.prototype[key],
         });
       }
     }
   }
 
   BindingRegistry.instance.registerBinding({
-    class: target,
+    binding: target,
     dependencies,
   });
 };
 
 export const Step: StepDecorator = (pattern, options) => (target) => {
-  let steps = Reflect.getMetadata("steps", target);
-
-  const step: StepMetadata = {
-    pattern,
-    options,
-  };
+  let steps = Reflect.getMetadata("steps", target) as StepMetadata[];
 
   if (!steps) {
     Reflect.defineMetadata("steps", (steps = []), target);
   }
 
-  steps.push(step);
+  steps.push({
+    pattern,
+    options,
+  });
 };
 
 export const Given = Step;

--- a/src/decorators/decorators.types.ts
+++ b/src/decorators/decorators.types.ts
@@ -1,4 +1,4 @@
-import { BindingDependency, StepOptions, StepPattern } from "../types";
+import { Class, StepOptions, StepPattern } from "../types";
 
 interface Constructor<T = {}> {
   new (...args: any[]): T;
@@ -12,6 +12,6 @@ type MethodDecorator = <This, Args extends any[], Return>(
   context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>,
 ) => void;
 
-export type BindingDecorator = (dependencies?: BindingDependency[]) => ClassDecorator;
+export type BindingDecorator = (dependencies?: Class[]) => ClassDecorator;
 
 export type StepDecorator = (pattern: StepPattern, options?: StepOptions) => MethodDecorator;

--- a/src/decorators/decorators.types.ts
+++ b/src/decorators/decorators.types.ts
@@ -1,11 +1,6 @@
 import { Class, StepOptions, StepPattern } from "../types";
 
-interface Constructor<T = {}> {
-  new (...args: any[]): T;
-  prototype: T;
-}
-
-type ClassDecorator = <Class extends Constructor>(target: Class, context: ClassDecoratorContext<Class>) => void;
+type ClassDecorator = <T extends Class>(target: T, context: ClassDecoratorContext<T>) => void;
 
 type MethodDecorator = <This, Args extends any[], Return>(
   target: (this: This, ...args: Args) => Return,

--- a/src/gherkin/feature.ts
+++ b/src/gherkin/feature.ts
@@ -29,9 +29,9 @@ export const loadFeature = (relativePath: string) => {
           for (const step of pickle.steps) {
             const { stepDefinition, args } = BindingRegistry.instance.getStep(step.text);
 
-            const instance = instanceManager.getOrSaveInstance(stepDefinition.classPrototype);
+            const instance = instanceManager.getOrSaveInstance(stepDefinition.binding);
 
-            await stepDefinition.definition.apply(instance, parseArguments(args));
+            await stepDefinition.method.apply(instance, parseArguments(args));
           }
           instanceManager.clear();
         });

--- a/src/gherkin/feature.ts
+++ b/src/gherkin/feature.ts
@@ -1,9 +1,11 @@
 import callsites from "callsites";
-import path from "path";
 import fs from "fs";
+import path from "path";
 
-import { GherkinParser } from "./parser";
+import { Argument } from "@cucumber/cucumber-expressions";
+import { InstanceManager } from "../instanceManager";
 import { BindingRegistry } from "../registry";
+import { GherkinParser } from "./parser";
 
 export const loadFeature = (relativePath: string) => {
   const callSite = callsites()[1];
@@ -22,16 +24,26 @@ export const loadFeature = (relativePath: string) => {
     describe(document.feature.name, () => {
       for (const pickle of pickles) {
         test(pickle.name, async () => {
-          for (const step of pickle.steps) {
-            const { stepDefinition } = BindingRegistry.instance.getStep(step.text);
+          const instanceManager = new InstanceManager();
 
-            console.log(stepDefinition.pattern, step.text);
-            // TODO
+          for (const step of pickle.steps) {
+            const { stepDefinition, args } = BindingRegistry.instance.getStep(step.text);
+
+            const instance = instanceManager.getOrSaveInstance(stepDefinition.classPrototype);
+
+            await stepDefinition.definition.apply(instance, parseArguments(args));
           }
+          instanceManager.clear();
         });
       }
     });
   } else {
     throw new Error(`No feature defined in ${uri}`);
   }
+};
+
+const parseArguments = <T>(args: readonly Argument[]): (T | null)[] => {
+  return args.map((arg) => {
+    return arg.getValue(this);
+  });
 };

--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -1,0 +1,52 @@
+import { BindingRegistry } from "./registry";
+import { Class } from "./types";
+
+export class InstanceManager {
+  private _instances = new Map<string, Class>();
+
+  public saveInstanceAndDeps(prototype: Class) {
+    const dependencies = BindingRegistry.instance.getDependencies(prototype);
+
+    if (dependencies.length === 0) {
+      const prototypeInstance = new prototype();
+      this._instances.set(prototype.name, prototypeInstance);
+    } else {
+      const initDeps = [];
+
+      for (const dependency of dependencies) {
+        this.saveInstanceAndDeps(dependency);
+
+        initDeps.push(this._instances.get(dependency.name));
+      }
+
+      const prototypeInstance = new prototype(...initDeps);
+      this._instances.set(prototype.name, prototypeInstance);
+    }
+  }
+
+  public getOrSaveInstance(prototype: Class): Class {
+    const instance = this._instances.get(prototype.name);
+
+    if (!instance) {
+      this.saveInstanceAndDeps(prototype);
+
+      return this.getOrSaveInstance(prototype);
+    } else {
+      return instance;
+    }
+  }
+
+  public getInstance(prototype: Class) {
+    const instance = this._instances.get(prototype.name);
+
+    if (!instance) {
+      throw new Error(`No instance found for ${prototype.name}`);
+    }
+
+    return instance;
+  }
+
+  public clear() {
+    this._instances.clear();
+  }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -36,6 +36,10 @@ export class BindingRegistry {
     }
   }
 
+  getDependencies(prototype: Class): Class[] {
+    return this._dependencies.get(prototype) || [];
+  }
+
   public getStep(text: string) {
     let foundStepDefinition;
     let foundArgs;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,6 +1,6 @@
 import { Expression, ExpressionFactory, ParameterTypeRegistry } from "@cucumber/cucumber-expressions";
 
-import { BindingDependency, ClassBinding, StepDefinition } from "./types";
+import { Class, ClassBinding, StepDefinition, StepDetails } from "./types";
 
 export class BindingRegistry {
   private static _instance: BindingRegistry;
@@ -9,7 +9,7 @@ export class BindingRegistry {
 
   private _expressionFactory = new ExpressionFactory(this._parameterTypeRegistry);
 
-  private _dependencies = new Map<any, BindingDependency[]>();
+  private _dependencies = new Map<any, Class[]>();
   private _steps = new Map<Expression, StepDefinition>();
 
   private constructor() {}
@@ -54,17 +54,20 @@ export class BindingRegistry {
     }
 
     if (!foundStepDefinition || !foundArgs) {
-      throw new Error(`No step definition found for "${text}"`);
+      throw new Error(
+        `No step definition found for "${text}".\nDid you decorate your step definition with a Step decorator (@Given, @When, @Then, ...)?\nIf you did, make sure you also decorate your class with the @Binding decorator.`,
+      );
     }
 
     return { stepDefinition: foundStepDefinition, args: foundArgs };
   }
 
-  public registerStep({ pattern, definition, options }: StepDefinition) {
+  public registerStep(classPrototype: Class, { pattern, definition, options }: StepDetails) {
     const stepExpression = this._expressionFactory.createExpression(pattern);
 
-    const step = {
+    const step: StepDefinition = {
       pattern,
+      classPrototype,
       definition,
       options,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,14 @@
-export type Class = new (...args: any[]) => any;
+interface Prototype {
+  [key: string | symbol]: any;
+}
 
-export type ClassBinding = {
-  class: Class;
+export type Class<T = Prototype> = {
+  new (...args: any[]): any;
+  prototype: T;
+};
+
+export type BindingDefinition = {
+  binding: Class;
   dependencies?: Class[];
 };
 
@@ -16,10 +23,7 @@ export type StepMetadata = {
   options?: StepOptions;
 };
 
-export type StepDetails = StepMetadata & {
-  definition: Function;
-};
-
-export type StepDefinition = StepDetails & {
-  classPrototype: Class;
+export type StepDefinition = StepMetadata & {
+  method: Function;
+  binding: Class;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
-export type BindingDependency = new () => any;
+export type Class = new (...args: any[]) => any;
 
 export type ClassBinding = {
-  class: any;
-  dependencies?: BindingDependency[];
+  class: Class;
+  dependencies?: Class[];
 };
 
 export type StepPattern = string | RegExp;
@@ -11,8 +11,15 @@ export type StepOptions = {
   timeout?: number;
 };
 
-export type StepDefinition = {
+export type StepMetadata = {
   pattern: StepPattern;
-  definition: Function;
   options?: StepOptions;
+};
+
+export type StepDetails = StepMetadata & {
+  definition: Function;
+};
+
+export type StepDefinition = StepDetails & {
+  classPrototype: Class;
 };


### PR DESCRIPTION
Closes #4 #9 

- **Chore**: Update the SWC decorator version for stage 3 decorators
- **Feature**: Store classPrototype in the stepDefinition.
> Now, the stepDefinition can store the class prototype, which simplifies the process of invoking the step function.
- **Feature**: Add a InstanceManager class
> This is a basic implementation of dependency injection.
- **Feature**: Step invocation
> The steps are now invoked with the correct classes, and parsed arguments.

> [!NOTE]
> Only cucumber expressions's arguments are parsed to the correct type. Regex expressions's arguments are **only strings**
