### PR TITLE
build: remove rootDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@tsconfig/recommended",
   "compilerOptions": {
     "lib": ["ES2021"],
-    "rootDir": ".",
     "outDir": "dist",
     "declaration": true,
     "sourceMap": true


### PR DESCRIPTION
### Description
Compilation outputs to dist/src which is wrong for package import in other projects.
Removed the `rootDir` directive, hopefully nothing breaks.