### PR TITLE
feat(types): add @Types decorator

### DIFF
--- a/src/__tests__/calculator.steps.ts
+++ b/src/__tests__/calculator.steps.ts
@@ -1,4 +1,4 @@
-import { Binding, Given, Then, When } from "../decorators";
+import { Binding, Given, Then, Types, When } from "../decorators";
 
 class Calculator {
   private readonly calculator: number[] = [];
@@ -18,10 +18,16 @@ export default class CalculatorSteps {
 
   constructor(readonly calculator: Calculator) {}
 
-  @Given("X is {int}")
-  @Given("Y is {int}")
+  @Given("E is {int}")
+  @Given("F is {int}")
   @Given(/[AB] is (\d)/)
   public stepIs(value: number) {
+    this.calculator.add(value);
+  }
+
+  @Given(/[CD] is (\d)/)
+  @Types([Number])
+  public stepIs2(value: number) {
     this.calculator.add(value);
   }
 
@@ -33,6 +39,12 @@ export default class CalculatorSteps {
   @Then("The result equals {int}")
   @Then(/The result is (\w+)/)
   public stepResult(expectedResult: number) {
+    expect(this.result).toStrictEqual(expectedResult);
+  }
+
+  @Then(/The result should be (\d)/)
+  @Types([Number])
+  public stepResult2(expectedResult: number) {
     expect(this.result).toStrictEqual(expectedResult);
   }
 }

--- a/src/__tests__/features/calculator.feature
+++ b/src/__tests__/features/calculator.feature
@@ -6,8 +6,14 @@ Feature: Calculator
     When I add the values
     Then The result is 012
 
-  Scenario: Subtract two numbers (with cucumber expressions)
-    Given X is 1
-    And Y is 2
+  Scenario: Add two numbers (with regular expressions and @Types)
+    Given C is 1
+    And D is 2
+    When I add the values
+    Then The result should be 3
+
+  Scenario: Add two numbers (with cucumber expressions)
+    Given E is 1
+    And F is 2
     When I add the values
     Then The result equals 3

--- a/src/__tests__/steps.test.ts
+++ b/src/__tests__/steps.test.ts
@@ -1,4 +1,4 @@
-import { Binding, Step } from "../decorators";
+import { Binding, Step, Types } from "../decorators";
 import { Steps } from "../steps";
 
 describe("Steps", () => {
@@ -17,6 +17,12 @@ describe("Steps", () => {
 
     @Step("I have a duplicate step")
     public stepC() {
+      return "step";
+    }
+
+    @Step("I have a step with more types than arguments")
+    @Types([Number])
+    public stepD() {
       return "step";
     }
   }
@@ -51,6 +57,10 @@ describe("Steps", () => {
 
     it("should throw en error if the class is not decorated with @Binding", () => {
       expect(() => Steps.instance.get("I have a new step")).toThrow();
+    });
+
+    it("should throw an error if the number of types is greater than the number of arguments", () => {
+      expect(() => Steps.instance.get("I have a step with more types than arguments")).toThrow();
     });
   });
 });

--- a/src/__tests__/transformers.test.ts
+++ b/src/__tests__/transformers.test.ts
@@ -1,0 +1,29 @@
+import { Transformers } from "../transfomers";
+
+describe("Boolean transformer", () => {
+  it("should transform 'true' to true", () => {
+    expect(Transformers.Boolean("true")).toBe(true);
+  });
+
+  it("should transform 'false' to false", () => {
+    expect(Transformers.Boolean("false")).toBe(false);
+  });
+
+  it("should throw when transforming an invalid boolean", () => {
+    expect(() => Transformers.Boolean("invalid")).toThrow();
+  });
+});
+
+describe("Booleanish transformer", () => {
+  it("should transform 'yes' to true", () => {
+    expect(Transformers.Booleanish("yes", "no")("yes")).toBe(true);
+  });
+
+  it("should transform 'no' to false", () => {
+    expect(Transformers.Booleanish("yes", "no")("no")).toBe(false);
+  });
+
+  it("should throw when transforming an invalid boolean", () => {
+    expect(() => Transformers.Booleanish("yes", "no")("invalid")).toThrow();
+  });
+});

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -4,9 +4,9 @@ import cloneDeep from "lodash.clonedeep";
 
 import { Dependencies } from "../dependencies";
 import { Steps } from "../steps";
-import type { StepMetadata } from "../types";
+import type { StepMetadata, TransformerMetadata } from "../types";
 
-import type { BindingDecorator, StepDecorator } from "./decorators.types";
+import type { BindingDecorator, StepDecorator, TypesDecorator } from "./decorators.types";
 
 export const Binding: BindingDecorator =
   (dependencies = []) =>
@@ -15,6 +15,7 @@ export const Binding: BindingDecorator =
 
     for (const key of propertyKeys) {
       const steps = Reflect.getMetadata("steps", target.prototype[key]) as StepMetadata[];
+      const transformers = Reflect.getMetadata("transformers", target.prototype[key]) as TransformerMetadata;
 
       if (steps) {
         for (const step of steps) {
@@ -22,6 +23,7 @@ export const Binding: BindingDecorator =
             ...cloneDeep(step),
             binding: target,
             method: target.prototype[key],
+            transformers,
           });
         }
       }
@@ -49,3 +51,7 @@ export const Step: StepDecorator =
 export const Given = Step;
 export const When = Step;
 export const Then = Step;
+
+export const Types: TypesDecorator = (transformers) => (target) => {
+  Reflect.defineMetadata("transformers", transformers, target);
+};

--- a/src/decorators/decorators.types.ts
+++ b/src/decorators/decorators.types.ts
@@ -1,4 +1,4 @@
-import type { Class, Method, StepOptions, StepPattern } from "../types";
+import type { Class, Method, StepOptions, StepPattern, Transformer } from "../types";
 
 type ClassDecorator = <T extends Class>(target: T, context: ClassDecoratorContext) => void;
 
@@ -6,3 +6,4 @@ type MethodDecorator = <T extends Method>(target: T, context: ClassMethodDecorat
 
 export type BindingDecorator = (dependencies?: Class[]) => ClassDecorator;
 export type StepDecorator = (pattern: StepPattern, options?: StepOptions) => MethodDecorator;
+export type TypesDecorator = (types: Transformer<any>[]) => MethodDecorator;

--- a/src/transfomers/booleanish.ts
+++ b/src/transfomers/booleanish.ts
@@ -1,0 +1,22 @@
+import type { Transformer } from "../types";
+
+type Bool = {
+  (): Transformer<boolean>;
+  (trueString: string, falseString: string): Transformer<boolean>;
+};
+
+export const Booleanish: Bool = (trueString = "true", falseString = "false") => {
+  return (value: string) => {
+    if (value === trueString) {
+      return true;
+    }
+
+    if (value === falseString) {
+      return false;
+    }
+
+    throw new Error(`Expected "${trueString}" or "${falseString}", but got "${value}"`);
+  };
+};
+
+export const Bool = Booleanish();

--- a/src/transfomers/index.ts
+++ b/src/transfomers/index.ts
@@ -1,0 +1,6 @@
+import { Bool, Booleanish } from "./booleanish";
+
+export const Transformers = {
+  Booleanish,
+  Boolean: Bool,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,9 @@ export type StepMetadata = {
 export type StepDefinition = StepMetadata & {
   method: Method;
   binding: Class;
+  transformers?: TransformerMetadata;
 };
+
+export type Transformer<T> = (value: string) => T;
+
+export type TransformerMetadata = Transformer<any>[];


### PR DESCRIPTION
### Description

Add a `@Types` decorator that allows regex pattern to have types.

**Definition**:
`@Types(transformers: Transformer<T>[])`

**Transformers**:
- Prebuilt: Number, String, Boolean. 
> [!WARNING]
> Boolean won't work in most cases because it returns true whenever a string is passed to it.
- Shipped with TSFlow: Boolean, Booleanish.
> [!TIP]
> - Boolean parse "true" to true and "false" to false. 
> - Booleanish can be used like this: `@Types([Booleanish("yes", "no")]`, where you specify a trueString and a falseString.
- Or create your own with a transfomer function that follows this type `type Transformer<T> = (value: string) => T`.

> [!CAUTION]
> The default transformer for regex pattern will be `String`.

**Examples**:
```ts
@Binding()
class A {
    @Step(/Regex Pattern (\d)/)
    public step(val: number) {
        return val + 1;
    }
}
```
When the step `Regex Pattern 3` will run, the result with be `31`.

You can add the `@Types` to resolve this problem:
```ts
@Binding()
class A {
    @Step(/Regex Pattern (\d)/)
    @Types([Number])
    public step(val: number) {
        return val + 1;
    }
}
```
Now when the step runs, the result will be `4`.
