### PR TITLE
feat(tag): add tags support

### DIFF
--- a/e2e/__tests__/__snapshots__/load-feature-tag-option.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/load-feature-tag-option.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadFeature tag options 1`] = `
+"PASS __tests__/index.test.ts
+  loadFeature with tag option - Scenario
+    ✓ Add two number
+    ✓ Add two number
+    ✓ Add two number
+  loadFeature with tag option - Scenario Outline
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)
+    ✓ Add two number (with Examples)"
+`;

--- a/e2e/__tests__/load-feature-tag-option.test.ts
+++ b/e2e/__tests__/load-feature-tag-option.test.ts
@@ -1,0 +1,10 @@
+import runJest from "../runJest";
+import { extractSummary } from "../utils";
+
+test("loadFeature tag options", () => {
+  const result = runJest("load-feature-tag-option");
+
+  const { rest } = extractSummary(result.stderr);
+
+  expect(rest).toMatchSnapshot();
+});

--- a/e2e/load-feature-tag-option/__tests__/index.test.ts
+++ b/e2e/load-feature-tag-option/__tests__/index.test.ts
@@ -1,0 +1,25 @@
+import { loadFeature } from "../../../src";
+
+import "../tagOption.steps";
+
+// None
+loadFeature("../tagOptionsScenario.feature", { tags: "@noTagWillMatch" });
+
+// And
+loadFeature("../tagOptionsScenario.feature", { tags: "@tagFeature1 and @tagFeature2" });
+
+// Not
+loadFeature("../tagOptionsScenario.feature", { tags: "not @tagFeature1" });
+
+// Or
+loadFeature("../tagOptionsScenario.feature", { tags: "@tagFeature1 or @tagFeature2" });
+
+// Scenario
+loadFeature("../tagOptionsScenario.feature", { tags: "@tagScenario" });
+
+// Scenario Outline
+loadFeature("../tagOptionsScenarioOutline.feature", { tags: "@tagScenarioOutline" });
+
+// Examples
+loadFeature("../tagOptionsScenarioOutline.feature", { tags: "@tagExamples1" });
+loadFeature("../tagOptionsScenarioOutline.feature", { tags: "@tagExamples2" });

--- a/e2e/load-feature-tag-option/package.json
+++ b/e2e/load-feature-tag-option/package.json
@@ -1,0 +1,9 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": ["<rootDir>/**/*.test.[jt]s"],
+    "transform": {
+      "^.+\\.[jt]s$": "ts-jest"
+    }
+  }
+}

--- a/e2e/load-feature-tag-option/tagOption.steps.ts
+++ b/e2e/load-feature-tag-option/tagOption.steps.ts
@@ -1,0 +1,35 @@
+import { Binding, Given, Then, When } from "../../src";
+
+class Calculator {
+  private readonly calculator: number[] = [];
+
+  public add(value: number) {
+    this.calculator.push(value);
+  }
+
+  public sum() {
+    return this.calculator.reduce((prev, cur) => prev + cur, 0);
+  }
+}
+
+@Binding([Calculator])
+export default class CalculatorSteps {
+  private result = 0;
+
+  constructor(readonly calculator: Calculator) {}
+
+  @Given("A/B is {int}")
+  public stepIs(value: number) {
+    this.calculator.add(value);
+  }
+
+  @When("I add the values")
+  public stepAddValues() {
+    this.result = this.calculator.sum();
+  }
+
+  @Then("The result equals {int}")
+  public stepResult(expectedResult: number) {
+    expect(this.result).toStrictEqual(expectedResult);
+  }
+}

--- a/e2e/load-feature-tag-option/tagOptionsScenario.feature
+++ b/e2e/load-feature-tag-option/tagOptionsScenario.feature
@@ -1,0 +1,9 @@
+@tagFeature1 @tagFeature2
+Feature: loadFeature with tag option - Scenario
+
+  @tagScenario
+  Scenario: Add two number
+    Given A is 1
+    And B is 2
+    When I add the values
+    Then The result equals 3

--- a/e2e/load-feature-tag-option/tagOptionsScenarioOutline.feature
+++ b/e2e/load-feature-tag-option/tagOptionsScenarioOutline.feature
@@ -1,0 +1,22 @@
+Feature: loadFeature with tag option - Scenario Outline
+
+  @tagScenarioOutline
+  Scenario Outline: Add two number (with Examples)
+    Given A is <a>
+    And B is <b>
+    When I add the values
+    Then The result equals <result>
+
+    @tagExamples1
+    Examples:
+      | a | b | result |
+      | 1 | 2 | 3      |
+      | 2 | 3 | 5      |
+      | 3 | 4 | 7      |
+
+    @tagExamples2
+    Examples:
+      | a | b | result |
+      | 1 | 2 | 3      |
+      | 2 | 3 | 5      |
+      | 3 | 4 | 7      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@cucumber/cucumber-expressions": "^17.1.0",
         "@cucumber/gherkin": "^28.0.0",
         "@cucumber/messages": "^24.1.0",
+        "@cucumber/tag-expressions": "^6.1.0",
         "callsites": "^3.0.0",
         "dedent": "^1.5.3",
         "execa": "^5.1.1",
@@ -1229,6 +1230,12 @@
     "node_modules/@cucumber/messages/node_modules/reflect-metadata": {
       "version": "0.2.1",
       "license": "Apache-2.0"
+    },
+    "node_modules/@cucumber/tag-expressions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.1.0.tgz",
+      "integrity": "sha512-+3DwRumrCJG27AtzCIL37A/X+A/gSfxOPLg8pZaruh5SLumsTmpvilwroVWBT2fPzmno/tGXypeK5a7NHU4RzA==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2743,10 +2750,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3898,7 +3907,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4642,6 +4653,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -10188,6 +10201,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@cucumber/cucumber-expressions": "^17.1.0",
     "@cucumber/gherkin": "^28.0.0",
     "@cucumber/messages": "^24.1.0",
+    "@cucumber/tag-expressions": "^6.1.0",
     "callsites": "^3.0.0",
     "dedent": "^1.5.3",
     "execa": "^5.1.1",

--- a/src/__tests__/binding.test.ts
+++ b/src/__tests__/binding.test.ts
@@ -1,6 +1,10 @@
 import { loadFeature } from "../gherkin/feature";
 
-import "./calculator.steps";
+import "./steps/calculator.steps";
+import "./steps/tag.steps";
 
 loadFeature("./features/calculator.feature");
 loadFeature(["./features/cal*.feature"]);
+
+loadFeature("./features/tag.feature", { tags: "@tag" });
+loadFeature("./features/tag.feature", { tags: "@scenario1" });

--- a/src/__tests__/features/tag.feature
+++ b/src/__tests__/features/tag.feature
@@ -1,0 +1,10 @@
+@tag
+Feature: Tag 
+
+  @scenario1
+  Scenario: Scenario 1
+    Then It should run
+
+  @scenario2
+  Scenario: Scenario 2
+    Then It should run

--- a/src/__tests__/steps/calculator.steps.ts
+++ b/src/__tests__/steps/calculator.steps.ts
@@ -1,5 +1,5 @@
-import { Binding, Given, Then, Types, When } from "../decorators";
-import type { DataTable } from "../gherkin";
+import { Binding, Given, Then, Types, When } from "../../decorators";
+import type { DataTable } from "../../gherkin";
 
 class Calculator {
   private readonly calculator: number[] = [];

--- a/src/__tests__/steps/tag.steps.ts
+++ b/src/__tests__/steps/tag.steps.ts
@@ -1,0 +1,9 @@
+import { Binding, Then } from "../../decorators";
+
+@Binding()
+class Tag {
+  @Then("It should run")
+  public getStep() {
+    return "step";
+  }
+}

--- a/src/gherkin/tags.ts
+++ b/src/gherkin/tags.ts
@@ -1,0 +1,11 @@
+import tagExpressionParser from "@cucumber/tag-expressions";
+
+type ParserFunction = { evaluate(variables: string[]): boolean };
+
+export const getTagParser = (tags?: string): ParserFunction | undefined => {
+  if (!tags) {
+    return;
+  }
+
+  return tagExpressionParser(tags);
+};


### PR DESCRIPTION
### Description
Adding support for [Tags](https://cucumber.io/docs/cucumber/api/?lang=javascript).

New definition of `loadFeatures`:
```ts
loadFeatures(patterns: string | string[], options?: Options)

type Options = {
   tags?: string
}
```