### PR TITLE
chore: publish npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "homepage": "https://github.com/baento/tsflow#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "@baento/tsflow",
   "version": "1.1.0-alpha.9",
   "author": "Antoine Balieu",
-  "private": true,
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
   "files": ["dist"],
   "homepage": "https://github.com/baento/tsflow#readme",
   "repository": {


### PR DESCRIPTION
### Description
- The NPM package is no longer private
- Include only `/dist` in published npm package