### PR TITLE
fix(entrypoint): added main, module and types to package.json

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "angular",
+        "preset": "conventionalcommits",
         "parserOpts": {
           "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
         },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "author": "Antoine Balieu",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     "default": "./dist/index.js",
     "import": "./dist/index.js",
+    "require": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "files": [


### PR DESCRIPTION
### Description
The NPM package missed some exports for tools such as bundlephobia or unpkg.
Also set the conventional commit preset from "angular" to "conventionalcommits" to match the rest of the config.